### PR TITLE
fix: tarnsform type value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ coverage
 .dumi/tmp-production
 dist
 .docs-dist
+.vscode

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type {
   InternalValidateMessages,
   Rule,
   RuleItem,
+  RuleType,
   RuleValuePackage,
   Rules,
   SyncErrorType,
@@ -146,11 +147,8 @@ class Schema {
           }
           value = source[z] = rule.transform(value);
           if (!rule.type) {
-            if (typeof value === 'number') {
-              rule.type = 'number';
-            } else if (Array.isArray(value)) {
-              rule.type = 'array';
-            }
+            const type = Array.isArray(value) ? 'array' : typeof value;
+            rule.type = type as RuleType;
           }
         }
         if (typeof rule === 'function') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,10 +146,7 @@ class Schema {
             source = { ...source };
           }
           value = source[z] = rule.transform(value);
-          if (!rule.type) {
-            const type = Array.isArray(value) ? 'array' : typeof value;
-            rule.type = type as RuleType;
-          }
+          rule.type ??= (Array.isArray(value) ? 'array' : typeof value) as RuleType;
         }
         if (typeof rule === 'function') {
           rule = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,13 @@ class Schema {
             source = { ...source };
           }
           value = source[z] = rule.transform(value);
+          if (!rule.type) {
+            if (typeof value === 'number') {
+              rule.type = 'number';
+            } else if (Array.isArray(value)) {
+              rule.type = 'array';
+            }
+          }
         }
         if (typeof rule === 'function') {
           rule = {

--- a/tests/deep.spec.ts
+++ b/tests/deep.spec.ts
@@ -222,7 +222,7 @@ describe('deep', () => {
         testArray: [],
       };
       const validator = new Schema(descriptor);
-      validator.validate(record, (errors, fields) => {
+      validator.validate(record, () => {
         done();
       });
     });

--- a/tests/number.spec.ts
+++ b/tests/number.spec.ts
@@ -109,6 +109,20 @@ describe('number', () => {
         done();
       });
   });
+  it('transform type', done => {
+    const value = { v: 'a' };
+    new Schema({
+      v: { required: true, type: 'number', transform: () => 0 },
+    })
+      .validate(value, errors => {
+        expect(value.v).toBe('a');
+        expect(errors).toBeFalsy();
+      })
+      .then(source => {
+        expect(source).toEqual({ v: 0 });
+        done();
+      });
+  });
   it('transform string', done => {
     const value = { v: 'a' };
     new Schema({

--- a/tests/number.spec.ts
+++ b/tests/number.spec.ts
@@ -115,7 +115,6 @@ describe('number', () => {
       v: { required: true, type: 'number', transform: () => 0 },
     })
       .validate(value, errors => {
-        expect(value.v).toBe('a');
         expect(errors).toBeFalsy();
       })
       .then(source => {
@@ -129,7 +128,6 @@ describe('number', () => {
       v: { required: true, transform: v => v },
     })
       .validate(value, errors => {
-        expect(value.v).toBe('a');
         expect(errors).toBeFalsy();
       })
       .then(source => {
@@ -143,7 +141,6 @@ describe('number', () => {
       v: { required: true, transform: v => v },
     })
       .validate(value, errors => {
-        expect(value.v).toBe(0);
         expect(errors).toBeFalsy();
       })
       .then(source => {
@@ -157,7 +154,6 @@ describe('number', () => {
       v: { required: true, transform: v => v },
     })
       .validate(value, errors => {
-        expect(value.v).toEqual([0, 1]);
         expect(errors).toBeFalsy();
       })
       .then(source => {

--- a/tests/number.spec.ts
+++ b/tests/number.spec.ts
@@ -109,4 +109,32 @@ describe('number', () => {
         done();
       });
   });
+  it('transform number', done => {
+    const value = { v: 0 };
+    new Schema({
+      v: { required: true, transform: v => v },
+    })
+      .validate(value, errors => {
+        expect(value.v).toBe(0);
+        expect(errors).toBeFalsy();
+      })
+      .then(source => {
+        expect(source).toEqual({ v: 0 });
+        done();
+      });
+  });
+  it('transform array', done => {
+    const value = { v: [0, 1] };
+    new Schema({
+      v: { required: true, transform: v => v },
+    })
+      .validate(value, errors => {
+        expect(value.v).toEqual([0, 1]);
+        expect(errors).toBeFalsy();
+      })
+      .then(source => {
+        expect(source).toEqual({ v: [0, 1] });
+        done();
+      });
+  });
 });

--- a/tests/number.spec.ts
+++ b/tests/number.spec.ts
@@ -109,6 +109,20 @@ describe('number', () => {
         done();
       });
   });
+  it('transform string', done => {
+    const value = { v: 'a' };
+    new Schema({
+      v: { required: true, transform: v => v },
+    })
+      .validate(value, errors => {
+        expect(value.v).toBe('a');
+        expect(errors).toBeFalsy();
+      })
+      .then(source => {
+        expect(source).toEqual({ v: 'a' });
+        done();
+      });
+  });
   it('transform number', done => {
     const value = { v: 0 };
     new Schema({


### PR DESCRIPTION
https://github.com/yiminghe/async-validator/issues/339

不传 transform，会走到这个方法，会识别 value 类型设置 type
```tsx
const required: ExecuteValidator = (rule, value, callback, source, options) => {
  const errors: string[] = [];
  const type = Array.isArray(value) ? 'array' : typeof value;
  rules.required(rule, value, source, errors, options, type);
  callback(errors);
};
```
所以在这里也增加 typeof 判断