### PR TITLE
if rule.message is null, it should be regarded as invalid, not only u…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ class Schema {
           if (!options.suppressWarning && errorList.length) {
             Schema.warning('async-validator:', errorList);
           }
-          if (errorList.length && rule.message !== undefined) {
+          if (errorList.length && rule.message !== undefined && rule.message !== null) {
             errorList = [].concat(rule.message);
           }
 


### PR DESCRIPTION
For this case:
```
rules=[{ required: true, message: null}]
```
A exception is thrown, because in src/util complementError, it tries to access `field` property of `rule.message`.

So I added:

```
rule.message !== null
```

if `rule.message` is null, it shouldn't be accessed.
