### PR TITLE
fix: restore browser targets

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -2,4 +2,7 @@ import { defineConfig } from 'father';
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  targets: {
+    ie: 11,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gh-pages": "npm run docs:build && npm run docs:deploy",
     "lint": "eslint src --ext .tsx,.ts,.jsx,.js",
     "now-build": "npm run docs:build",
-    "prepublishOnly": "npm run compile && np --yolo --no-publish",
+    "prepublishOnly": "npm run compile && rc-np",
     "prettier": "prettier . --write",
     "postpublish": "npm run gh-pages",
     "start": "dumi dev",
@@ -49,7 +49,8 @@
     "@babel/runtime": "^7.24.4"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^1.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
+    "@rc-component/np": "^1.0.3",
     "@types/jest": "^29.5.12",
     "@types/react": "18.x",
     "@types/react-dom": "18.x",
@@ -59,7 +60,6 @@
     "father": "^4.4.0",
     "gh-pages": "^6.1.1",
     "lint-staged": "^15.2.2",
-    "np": "^10.0.3",
     "prettier": "^3.2.5",
     "rc-test": "^7.0.15",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- Upgrade to the latest rc father plugin publish flow.
- Restore the browser compile target to the previous Father default with `targets: { ie: 11 }`.
- Prevent modern syntax from leaking into the published `es` and `lib` output for older webpack parsers.

## Root Cause
`@rc-component/father-plugin@2.2.0` defaults `targets` to `{ chrome: 85 }`, which is newer than the previous Father browser default. Without an explicit override, the published output can keep syntax that older webpack parsers cannot parse.

## Verification
- `npm run compile`
- `acorn@6` parses all generated `es` and `lib` JavaScript files after the fix
- `npm test -- --runInBand`
